### PR TITLE
friend declarations in big.h and zzn.h

### DIFF
--- a/include/big.h
+++ b/include/big.h
@@ -299,7 +299,7 @@ public:
               {if (mr_compare(b1.fn,b2.fn)>0) return TRUE; else return FALSE;}
 
     friend Big from_binary(int,char *);
-    friend int to_binary(const Big&,int,char *,BOOL justify=FALSE);
+    friend int to_binary(const Big&,int,char *,BOOL);
     friend Big modmult(const Big&,const Big&,const Big&);
     friend Big mad(const Big&,const Big&,const Big&,const Big&,Big&);
     friend Big norm(const Big&);
@@ -321,7 +321,7 @@ public:
                                                          // x^m.y^k mod n 
     friend Big pow(int,Big *,Big *,Big);  // x[0]^m[0].x[1].m[1]... mod n
 
-    friend Big luc(const Big& ,const Big&, const Big&, Big *b4=NULL);
+    friend Big luc(const Big& ,const Big&, const Big&, Big *);
 	friend Big moddiv(const Big&,const Big&,const Big&);
     friend Big inverse(const Big&, const Big&);
     friend void multi_inverse(int,Big*,const Big&,Big *);
@@ -353,8 +353,8 @@ public:
     friend void modulo(const Big&);
     friend BOOL modulo(int,int,int,int,BOOL);
     friend Big get_modulus(void);
-    friend int window(const Big&,int,int*,int*,int window_size=5);
-    friend int naf_window(const Big&,const Big&,int,int*,int*,int store=11);
+    friend int window(const Big&,int,int*,int*,int);
+    friend int naf_window(const Big&,const Big&,int,int*,int*,int);
     friend void jsf(const Big&,const Big&,Big&,Big&,Big&,Big&);
 
 /* Montgomery stuff */
@@ -420,7 +420,12 @@ extern Big get_modulus(void);
 extern Big rand(int,int); 
 extern Big strong_rand(csprng *,int,int);
 extern Big from_binary(int,char *);
-extern int to_binary(const Big&,int,char *,BOOL);
+extern int to_binary(const Big&,int,char *,BOOL justify=FALSE);
+
+// Forward Declaration for friend declaration to allow definition in cpp.
+int window(const Big& x,int i,int *nbs,int *nzs,int window_size=5);
+int naf_window(const Big& x,const Big& x3,int i,int *nbs,int *nzs,int store=11);
+Big luc(const Big& b1,const Big& b2,const Big& b3,Big *b4=NULL);
 
 using namespace std;
 

--- a/include/zzn.h
+++ b/include/zzn.h
@@ -183,7 +183,7 @@ public:
     friend ZZn getB(void);        // get B parameter of elliptic curve
 
     friend ZZn  sqrt(const ZZn&); // only works if modulus is prime
-    friend ZZn  luc( const ZZn&, const Big&, ZZn* b3=NULL);
+    friend ZZn  luc( const ZZn&, const Big&, ZZn*);
 
     big getzzn(void) const;
 
@@ -209,3 +209,5 @@ extern ZZn one(void);
 
 #endif
 
+// Forward Declaration for friend declaration to allow definition in cpp.
+ZZn luc(const ZZn&, const Big&, ZZn* b3=NULL);


### PR DESCRIPTION
Friends declared in a header file cannot include default parameter arguments without a function definition. So we should forward declare friends in the header. This change addresses compiler errors due to clang strictness on OS X.
