### PR TITLE
Correct bug in BPS encryption algorithm

### DIFF
--- a/source/mrfpe.c
+++ b/source/mrfpe.c
@@ -201,7 +201,7 @@ void FPE_encrypt(int s,aes *a,UINT32 TL,UINT32 TR,char *x,int len)
 	}
 	rest=len%mb;
 	c=0; i=0;
-	while (len-c>mb)
+	while (len-c>=mb)
 	{
 		if (i!=0) for (j=c;j<c+mb;j++) x[j]=(x[j]+x[j-mb])%s;
 		BC(ENCRYPT,&x[c],mb,s,a,TL^(i<<16),TR^(i<<16));


### PR DESCRIPTION
There is a typo in the algorithm 3 (the encryption algorithm) in [1].
This has the consequence that when the plaintext length is longer than maxb (i.e. when you use the Mode of Operation described in the section 1.2 of [1]) and the plaintext length is a multiple of maxb, FPE_decrypt(FPE_encrypt(X)) != X.
You can test this case easily by changing the line 314 of mrfpe.c to n=112.
In this case, the radix s is 10 which mean maxb(s) = 56.
You can see that the plaintext obtained by decrypting the ciphertext is not equal to the original plaintext.

[1] BPS: a Format-Preserving Encryption Proposal, Eric Brier, Thomas Peyrin and Jacques Stern, 
http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/bps/bps-spec.pdf
