### PR TITLE
rename fmt() to fmth() to avoid name clash with fmtlib

### DIFF
--- a/include/big.h
+++ b/include/big.h
@@ -274,7 +274,7 @@ public:
     friend Big operator*(int,const Big&);
     friend Big operator*(const Big&,const Big&);
 
-    friend BOOL fmt(int n,const Big&,const Big&,Big&);   // fast mult - top half
+    friend BOOL fmth(int n,const Big&,const Big&,Big&);   // fast mult - top half
 
     friend Big operator/(const Big&,int);
     friend Big operator/(const Big&,const Big&);

--- a/source/big.cpp
+++ b/source/big.cpp
@@ -78,7 +78,7 @@ Big operator*(const Big& b1, const Big& b2)
 {Big xbb; multiply(b1.fn,b2.fn,xbb.fn); return xbb;}
 
 #ifndef MR_STATIC
-BOOL fmt(int n,const Big& b1,const Big& b2,Big& f)
+BOOL fmth(int n,const Big& b1,const Big& b2,Big& f)
 {
 #ifdef MR_KCM
  return kcm_top(n,b1.fn,b2.fn,f.fn);       /* see mrkcm.tpl */

--- a/source/floating.cpp
+++ b/source/floating.cpp
@@ -578,7 +578,7 @@ Float& Float::operator*=(const Float& b)
     {
         if (m<0) m.negate();  // result will be positive
         m.shift(precision-length(m));  // make them precision length
-        extra=fmt(precision,m,m,m);
+        extra=fmth(precision,m,m,m);
         e+=e;
         if (extra) e--;
     }
@@ -593,7 +593,7 @@ Float& Float::operator*=(const Float& b)
         m.shift(precision-length(m));  // make them precision length
         y.shift(precision-length(y));
 
-        extra=fmt(precision,m,y,m);
+        extra=fmth(precision,m,y,m);
 
         if (s<0) m.negate();
         e+=b.e;

--- a/source/mrkcm.tpl
+++ b/source/mrkcm.tpl
@@ -435,7 +435,7 @@ void kcm_square(_MIPD_ int n,big x,big z)
 }
 
 BOOL kcm_top(_MIPD_ int n,big x,big y,big z)
-{ /* to support floating-point - see float.cpp and fmt function in big.cpp */
+{ /* to support floating-point - see float.cpp and fmth function in big.cpp */
 #ifdef MR_OS_THREADS
     miracl *mr_mip=get_mip();
 #endif


### PR DESCRIPTION
The popular fmt string formatting library [0] uses `fmt` as its namespace,
so using MIRACL and fmt together in one project causes name clashes.  It
would be even better if MIRACL used a namespace themselves, like
`miracl` to generally avoid such name clashes...

[0] https://github.com/fmtlib/fmt