### PR TITLE
docs: fix simple typo, permuation -> permutation

### DIFF
--- a/source/limlee.cpp
+++ b/source/limlee.cpp
@@ -123,7 +123,7 @@ int main()
 
     permutation=1L;
     for (i=0;i<np;i++) permutation<<=1;
-    permutation-=1;     /* permuation = 2^np-1 */
+    permutation-=1;     /* permutation = 2^np-1 */
 
 /* generate p   */
     fail=FALSE;


### PR DESCRIPTION
There is a small typo in source/limlee.cpp.

Should read `permutation` rather than `permuation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md